### PR TITLE
Implement StackTrace on Throw

### DIFF
--- a/src/script.rs
+++ b/src/script.rs
@@ -31,7 +31,7 @@ pub fn run_js_in_scope(scope: &mut v8::HandleScope, js: &str) -> String {
 
         eprintln!("{}", result);
 
-        return result;
+        return "".to_string();
     }
 
     if result.is_none() {

--- a/src/script.rs
+++ b/src/script.rs
@@ -24,6 +24,16 @@ pub fn run_js_in_scope(scope: &mut v8::HandleScope, js: &str) -> String {
 
     let result = script.run(tc_scope);
 
+    if let Some(stack_trace) = tc_scope.stack_trace() {
+        let result = stack_trace.to_string(tc_scope).unwrap();
+        let result = result.to_string(tc_scope).unwrap();
+        let result = result.to_rust_string_lossy(tc_scope);
+
+        println!("{}", result);
+
+        return result;
+    }
+
     if result.is_none() {
         let exception = tc_scope.exception().unwrap();
         let msg = v8::Exception::create_message(tc_scope, exception);

--- a/src/script.rs
+++ b/src/script.rs
@@ -29,7 +29,7 @@ pub fn run_js_in_scope(scope: &mut v8::HandleScope, js: &str) -> String {
         let result = result.to_string(tc_scope).unwrap();
         let result = result.to_rust_string_lossy(tc_scope);
 
-        println!("{}", result);
+        eprintln!("{}", result);
 
         return result;
     }


### PR DESCRIPTION
Prints the StackTrace when throwing.

## Example

JavaScript File:

```js
// test.js
function willThrowInTheFuture() {
  meThrow();
}

function meThrow() {
  throw new Error('me throwing so bad!');
}

willThrowInTheFuture();

```

```bash
cargo run ./test.js
```

### Output

```
Error: me throwing so bad!
    at meThrow (<anonymous>:6:9)
    at willThrowInTheFuture (<anonymous>:2:3)
    at <anonymous>:9:1
```

