### PR TITLE
src: inital implementation of ESM

### DIFF
--- a/fixtures/deep/hello.mjs
+++ b/fixtures/deep/hello.mjs
@@ -1,0 +1,5 @@
+const hello = 'hello';
+
+export {
+  hello
+};

--- a/fixtures/deep/once.mjs
+++ b/fixtures/deep/once.mjs
@@ -1,0 +1,7 @@
+console.log('This should only be logged once.');
+
+const once = 1;
+
+export {
+  once
+};

--- a/fixtures/deep/phrase.mjs
+++ b/fixtures/deep/phrase.mjs
@@ -1,0 +1,2 @@
+export {hello} from './hello.mjs';
+export {world} from './world.mjs';

--- a/fixtures/deep/world.mjs
+++ b/fixtures/deep/world.mjs
@@ -1,0 +1,5 @@
+const world = 'world';
+
+export {
+  world
+};

--- a/fixtures/deep/world.mjs
+++ b/fixtures/deep/world.mjs
@@ -1,5 +1,8 @@
+import { once } from './once.mjs';
+
 const world = 'world';
 
 export {
-  world
+  world,
+  once
 };

--- a/fixtures/module.mjs
+++ b/fixtures/module.mjs
@@ -1,0 +1,3 @@
+import {hello, world} from './deep/phrase.mjs';
+
+console.log(`${hello} ${world}`);

--- a/fixtures/module.mjs
+++ b/fixtures/module.mjs
@@ -1,3 +1,4 @@
 import {hello, world} from './deep/phrase.mjs';
+import {once} from './deep/once.mjs';
 
-console.log(`${hello} ${world}`);
+console.log(`${hello} ${world} exactly ${once} time`);

--- a/src/js_loading.rs
+++ b/src/js_loading.rs
@@ -1,0 +1,31 @@
+use rusty_v8 as v8;
+
+// Common code used by both `module.rs` and `script.rs`
+
+pub(crate) fn create_script_origin<'s>(
+    scope: &mut v8::HandleScope<'s, ()>,
+    filepath: v8::Local<'s, v8::String>,
+    is_module: bool,
+) -> v8::ScriptOrigin<'s> {
+    let resource_name = filepath.into();
+    let resource_line_offset = v8::Integer::new(scope, 0);
+    let resource_column_offset = v8::Integer::new(scope, 0);
+    let resource_is_shared_cross_origin = v8::Boolean::new(scope, false);
+    let script_id = v8::Integer::new(scope, 0);
+    let source_map_url = v8::String::new(scope, "").unwrap().into();
+    let resource_is_opaque = v8::Boolean::new(scope, true);
+    let is_wasm = v8::Boolean::new(scope, false);
+    let is_module = v8::Boolean::new(scope, is_module);
+
+    v8::ScriptOrigin::new(
+        resource_name,
+        resource_line_offset,
+        resource_column_offset,
+        resource_is_shared_cross_origin,
+        script_id,
+        source_map_url,
+        resource_is_opaque,
+        is_wasm,
+        is_module,
+    )
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
 mod binding;
 mod bootstrap;
+mod js_loading;
+pub mod module;
 pub mod script;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,8 @@ use structopt::StructOpt;
 
 mod binding;
 mod bootstrap;
+mod js_loading;
+mod module;
 mod repl;
 mod script;
 
@@ -58,6 +60,6 @@ fn main() {
 
     match filename {
         "-" => repl::start(),
-        _ => script::run_file(filename),
+        _ => module::run_file(filename),
     }
 }


### PR DESCRIPTION
OK, so it's been a minute since I've done anything with Rust or V8, but here's some inital ESM support. The main caveats are:

* Right now it only handles either absolute paths or relative to `$PWD`.
* If a module appears twice in the tree, it will be loaded twice. There is no cache. That's a TODO. A big TODO.

<!--
Thank you for your pull request. Please provide a description of your change.

Contributors guide: https://github.com/jstime/jstime/blob/HEAD/CONTRIBUTING.md
-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
