### PR TITLE
repl: persistent history

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,6 +112,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142995ed02755914747cc6ca76fc7e4583cd18578746716d0508ea6ed558b9ff"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs-next"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -119,6 +128,17 @@ checksum = "1cbcf9241d9e8d106295bd496bbe2e9cffd5fa098f2a8c9e2bbcbf09773c11a8"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -165,6 +185,7 @@ dependencies = [
 name = "jstime"
 version = "0.13.2-alpha.0"
 dependencies = [
+ "dirs",
  "jstime_core",
  "rustyline",
  "structopt",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -17,6 +17,7 @@ path = "main.rs"
 jstime_core = { path = "../core", version = "^0.13.2-alpha.0"}
 rustyline = "6.2.0"
 structopt = "0.3.17"
+dirs = "3.0.1"
 
 [build-dependencies]
 jstime_core = { path = "../core", version = "^0.13.2-alpha.0"}

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -60,7 +60,7 @@ fn repl(mut jstime: jstime::JSTime) {
     let mut rl = Editor::<()>::new();
     println!("Welcome to jstime v{}!", env!("CARGO_PKG_VERSION"));
 
-    if rl.load_history(&history_path).is_err() {}
+    let _ = rl.load_history(&history_path);
 
     loop {
         let readline = rl.readline(">> ");

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -52,9 +52,15 @@ fn main() {
 
 fn repl(mut jstime: jstime::JSTime) {
     use rustyline::{error::ReadlineError, Editor};
+    use dirs::home_dir;
+    
+    let mut history_path = home_dir().unwrap();
+    history_path.push(".jstime_repl_history");
 
     let mut rl = Editor::<()>::new();
     println!("Welcome to jstime v{}!", env!("CARGO_PKG_VERSION"));
+    
+    if rl.load_history(&history_path).is_err() {}
 
     loop {
         let readline = rl.readline(">> ");
@@ -80,4 +86,5 @@ fn repl(mut jstime: jstime::JSTime) {
             }
         }
     }
+    rl.save_history(&history_path).unwrap();
 }

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -51,15 +51,15 @@ fn main() {
 }
 
 fn repl(mut jstime: jstime::JSTime) {
-    use rustyline::{error::ReadlineError, Editor};
     use dirs::home_dir;
-    
+    use rustyline::{error::ReadlineError, Editor};
+
     let mut history_path = home_dir().unwrap();
     history_path.push(".jstime_repl_history");
 
     let mut rl = Editor::<()>::new();
     println!("Welcome to jstime v{}!", env!("CARGO_PKG_VERSION"));
-    
+
     if rl.load_history(&history_path).is_err() {}
 
     loop {

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -86,5 +86,5 @@ fn repl(mut jstime: jstime::JSTime) {
             }
         }
     }
-    rl.save_history(&history_path).unwrap();
+    let _ = rl.save_history(&history_path);
 }

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -54,13 +54,14 @@ fn repl(mut jstime: jstime::JSTime) {
     use dirs::home_dir;
     use rustyline::{error::ReadlineError, Editor};
 
-    let mut history_path = home_dir().unwrap();
-    history_path.push(".jstime_repl_history");
-
     let mut rl = Editor::<()>::new();
     println!("Welcome to jstime v{}!", env!("CARGO_PKG_VERSION"));
 
-    let _ = rl.load_history(&history_path);
+    let history_path = home_dir().map(|mut p| {
+        p.push(".jstime_repl_history");
+        let _ = rl.load_history(&p);
+        p
+    });
 
     loop {
         let readline = rl.readline(">> ");
@@ -86,5 +87,8 @@ fn repl(mut jstime: jstime::JSTime) {
             }
         }
     }
-    let _ = rl.save_history(&history_path);
+
+    if let Some(history_path) = history_path {
+        let _ = rl.save_history(&history_path);
+    }
 }


### PR DESCRIPTION
Uses the dirs crate to get home_dir

History is saved at `~/.jstime_repl_history`

Fixes: https://github.com/jstime/jstime/issues/42
