### PR TITLE
errorHandling: fix error code in javascript from 0 to 1

### DIFF
--- a/cli/main.rs
+++ b/cli/main.rs
@@ -41,10 +41,13 @@ fn main() {
     let mut jstime = jstime::JSTime::new(options);
 
     if let Some(filename) = opt.filename {
-        match jstime.import(&filename) {
-            Ok(_) => {}
-            Err(e) => eprintln!("{}", e),
-        }
+        std::process::exit(match jstime.import(&filename) {
+            Ok(_) => 0,
+            Err(e) => {
+                eprintln!("{:?}", e);
+                1
+            }
+        });
     } else {
         repl(jstime);
     }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description of your change.

Contributors guide: https://github.com/jstime/jstime/blob/HEAD/CONTRIBUTING.md
-->

Switches error exit code handling in main.rs for javascript files. Using std::process::exit, switches exit code for errors from 0 to 1.

Fixes https://github.com/jstime/jstime/issues/38

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
