### PR TITLE
cli: print newlines for errors

### DIFF
--- a/cli/main.rs
+++ b/cli/main.rs
@@ -44,7 +44,7 @@ fn main() {
         std::process::exit(match jstime.import(&filename) {
             Ok(_) => 0,
             Err(e) => {
-                eprintln!("{:?}", e);
+                eprintln!("{}", e);
                 1
             }
         });


### PR DESCRIPTION
Right now the entire error message is being printed as a string
and newlines are not being respected in the output. Fix that
by printing string in a way that preserves newlines in the console.
