### PR TITLE
repl: Pass the runtime as ref

### DIFF
--- a/cli/main.rs
+++ b/cli/main.rs
@@ -48,11 +48,11 @@ fn main() {
             }
         });
     } else {
-        repl(jstime);
+        repl(&mut jstime);
     }
 }
 
-fn repl(mut jstime: jstime::JSTime) {
+fn repl(jstime: &mut jstime::JSTime) {
     use dirs::home_dir;
     use rustyline::{error::ReadlineError, Editor};
 


### PR DESCRIPTION
I think it better to pass the `jstime::JSTime` object as a reference, so it won't be cloned.
