### PR TITLE
add basic formatter  support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target/
+.vscode/

--- a/cli/tests/fixtures/console-printer.js
+++ b/cli/tests/fixtures/console-printer.js
@@ -1,0 +1,5 @@
+console.log('first', '%second', 'third');
+console.log('first%s', 'second', 'third');
+console.log('first %s', 'second', 'third');
+console.log('first %s %s', 'second', '3');
+console.log('first %s %s', 'second')

--- a/cli/tests/test_cli.rs
+++ b/cli/tests/test_cli.rs
@@ -79,11 +79,13 @@ fn console() {
         .unwrap()
         .arg("./tests/fixtures/console-printer.js")
         .assert()
-        .stdout(r#"first %second third
+        .stdout(
+            r#"first %second third
 first%s second third
 first second third
 first second 3
 first second %s
-"#)
+"#,
+        )
         .code(0);
 }

--- a/cli/tests/test_cli.rs
+++ b/cli/tests/test_cli.rs
@@ -72,3 +72,18 @@ fn invalid_code() {
         .failure()
         .code(1);
 }
+
+#[test]
+fn console() {
+    Command::cargo_bin("jstime")
+        .unwrap()
+        .arg("./tests/fixtures/console-printer.js")
+        .assert()
+        .stdout(r#"first %second third
+first%s second third
+first second third
+first second 3
+first second %s
+"#)
+        .code(0);
+}

--- a/core/src/builtins/console.js
+++ b/core/src/builtins/console.js
@@ -16,6 +16,46 @@
     }
   }
 
+  function formatter(args) {
+    let target = args[0];
+    let current = args[1];
+
+    let i = target.indexOf(' %')
+    if (i === -1) {
+      return args;
+    }
+
+    let converted;
+    const specifier = target[i + 2];
+    if (specifier === 's') {
+      converted = String(current);
+    } else if (specifier === 'd' || specifier === 'i') {
+      if (typeof current === 'symbol') {
+        converted = NaN;
+      } else {
+        converted = parseInt(current, 10);
+      }
+    } else if (specifier === 'f') {
+      if (typeof current === 'symbol') {
+        converted = NaN;
+      } else {
+        converted = parseFloat(current);
+      }
+      // TODO: %o, %O
+    }
+
+    if (converted) {
+      target = target.substring(0, i + 1) + converted + target.substring(i + 3, target.length);
+    }
+
+    const result = [target, ...args.slice(2)];
+    if (i === target.length - 3 || result.length === 1) {
+      return result;
+    }
+
+    return (formatter(result));
+  }
+
   function logger(loglevel, args) {
     if (!args.length) {
       return;
@@ -27,9 +67,7 @@
       return;
     }
 
-    // TODO Handle Format Specifiers
-
-    printer(loglevel, args);
+    printer(loglevel, formatter(args));
   }
 
   let inConsoleCall = false;

--- a/core/tests/test_api.rs
+++ b/core/tests/test_api.rs
@@ -3,7 +3,7 @@ use jstime_core as jstime;
 mod common;
 
 #[cfg(test)]
-mod tests {
+mod api {
     use super::*;
     #[test]
     fn run_script() {


### PR DESCRIPTION
Part of #4.
Struggling a bit with how to add tests, as `console.log` will always return `undefine`. I guess that could be solved if we can pass a buffer to `printer` somehow? @MylesBorins 

