### PR TITLE
doc: improve embedding documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ hello world
 
 ```
 
+## Embed it!
+
+Check out the [README.md for jstime-core](./core/README.md) for
+instructions on how to embed jstime in your rust application!
+
 ## Current Project Team Members
 
 for information about the governance of the jstime project, see

--- a/core/README.md
+++ b/core/README.md
@@ -6,9 +6,14 @@ which provides the V8-Rust bindings.
 ## API
 
 ```rust
-use jstime_core::module;
+use jstime_core as jstime;
 
 fn main() {
-  module::run("console.log('hello world')");
+    jstime::init(None);
+    let mut scope = jstime::JSTime::new(
+        jstime::Options::default()
+    );
+    scope.run_script("console.log('Hello, World!');", "jstime")
+        .expect("ruhroh something went wrong");
 }
 ```


### PR DESCRIPTION
The README.md in jstime-core was out of date.

* Update embedding documentation in core/README.md
* Update ./README.md to reference embedding documentation

Refs: https://github.com/jstime/embedding-demo
