### PR TITLE
governance: no longer require collaborator review

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -17,14 +17,17 @@ Both Collaborators and non-Collaborators may propose changes to the jstime sourc
 code. The mechanism to propose such a change is a GitHub pull request. Collaborators
 review and merge (land) pull requests.
 
-One Collaborator must approve a pull request before the pull request can land.
-Approving a pull request indicates that the Collaborator accepts responsibility for
-the change. Approval must be from Collaborators who are not authors of the change.
+Pull Request authored by non-collaborators require at least one approval from a 
+Collaborator. Approving a pull request indicates that the  Collaborator accepts 
+responsibility for the change.
 
-*Note*: Approval is not required for changes related to documentation, tooling, or releases.
+Pull Requests authored by a collabortor do not require review, but it is 
+encouraged. If no review is given the collaborator should document the reason
+for landing without review.
 
 If a Collaborator opposes a proposed change, then the change cannot land unless
-the chair determines there is [rough consensus][] to move forward.
+consensus to land can be reached or the chair determines there is
+[rough consensus][] to move forward.
 
 See:
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -18,7 +18,7 @@ code. The mechanism to propose such a change is a GitHub pull request. Collabora
 review and merge (land) pull requests.
 
 Pull Request authored by non-collaborators require at least one approval from a 
-Collaborator. Approving a pull request indicates that the  Collaborator accepts 
+Collaborator. Approving a pull request indicates that the Collaborator accepts 
 responsibility for the change.
 
 Pull Requests authored by a collabortor do not require review, but it is 


### PR DESCRIPTION
It dawned on me that our governance can currently be changed via a
PR with no review in 7 days but our code base cannot. That doesn't
seem right. I've updated the governance to no longer make review of
a collaborators change required, but it does require documentation of
the reason for landing without review.

At the current time this really seems necessary as small changes
have been taking 2+ weeks to get a single review.

Refs: https://github.com/jstime/jstime/pull/79
Closes: https://github.com/jstime/jstime/issues/53

<!--
Thank you for your pull request. Please provide a description of your change.

Contributors guide: https://github.com/jstime/jstime/blob/HEAD/CONTRIBUTING.md
-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
