### PR TITLE
Revert rusty V8 0.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,9 +337,9 @@ dependencies = [
 
 [[package]]
 name = "rusty_v8"
-version = "0.17.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4cacd73b88c22512f09c5ec78e56eb89d95e4dc1201fe52bd6c81824b5e041b"
+checksum = "a50f63f3030b5a676b9f6e7d53bf1f880904973c2350a3f034dbf82facca0b4f"
 dependencies = [
  "bitflags",
  "cargo_gn",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 repository = "https://github.com/jstime/jstime"
 
 [dependencies]
-rusty_v8 = "0.17.0"
+rusty_v8 = "0.16.0"
 lazy_static = "1.4.0"
 
 [package.metadata.release]

--- a/core/src/module.rs
+++ b/core/src/module.rs
@@ -103,7 +103,6 @@ fn normalize_path(referrer_path: &str, requested: &str) -> String {
 fn resolve_callback<'a>(
     context: v8::Local<'a, v8::Context>,
     specifier: v8::Local<'a, v8::String>,
-    _import_assertions: v8::Local<'a, v8::FixedArray>,
     referrer: v8::Local<'a, v8::Module>,
 ) -> Option<v8::Local<'a, v8::Module>> {
     let scope = unsafe { &mut v8::CallbackScope::new(context) };


### PR DESCRIPTION
Alas this upgrade broke module resolution. I poked at it a bit and wasn't able to quickly figure out why everything was blowing up, but I did write some tests that will help us avoid this in the future. Let's revert quickly and make a new release so we can figure out what's busted