### PR TITLE
deps: s/rusty_v8/v8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,7 +289,7 @@ name = "jstime_core"
 version = "0.35.1-alpha.0"
 dependencies = [
  "lazy_static",
- "rusty_v8",
+ "v8",
 ]
 
 [[package]]
@@ -516,19 +516,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
 
 [[package]]
-name = "rusty_v8"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b311db3661f6b7631f94ad431133ff0f299c423e6bcc35b748ad0d57d6e604"
-dependencies = [
- "bitflags",
- "fslock",
- "lazy_static",
- "libc",
- "which",
-]
-
-[[package]]
 name = "rustyline"
 version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -664,6 +651,19 @@ name = "utf8parse"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
+
+[[package]]
+name = "v8"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b3adb16fd1af3e28d6fda8348a6d96b5363a128dc5a0216b137b64ecbae6641"
+dependencies = [
+ "bitflags",
+ "fslock",
+ "lazy_static",
+ "libc",
+ "which",
+]
 
 [[package]]
 name = "vec_map"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 repository = "https://github.com/jstime/jstime"
 
 [dependencies]
-rusty_v8 = "0.32.0"
+v8 = "0.33.0"
 lazy_static = "1.4.0"
 
 [package.metadata.release]

--- a/core/src/builtins/mod.rs
+++ b/core/src/builtins/mod.rs
@@ -1,5 +1,4 @@
 use std::convert::TryFrom;
-use v8;
 
 lazy_static! {
     pub(crate) static ref EXTERNAL_REFERENCES: v8::ExternalReferences =

--- a/core/src/builtins/mod.rs
+++ b/core/src/builtins/mod.rs
@@ -1,5 +1,5 @@
-use rusty_v8 as v8;
 use std::convert::TryFrom;
+use v8;
 
 lazy_static! {
     pub(crate) static ref EXTERNAL_REFERENCES: v8::ExternalReferences =

--- a/core/src/isolate_state.rs
+++ b/core/src/isolate_state.rs
@@ -1,6 +1,5 @@
 use std::cell::RefCell;
 use std::rc::Rc;
-use v8;
 
 pub(crate) struct IsolateState {
     pub(crate) context: Option<v8::Global<v8::Context>>,

--- a/core/src/isolate_state.rs
+++ b/core/src/isolate_state.rs
@@ -1,6 +1,6 @@
-use rusty_v8 as v8;
 use std::cell::RefCell;
 use std::rc::Rc;
+use v8;
 
 pub(crate) struct IsolateState {
     pub(crate) context: Option<v8::Global<v8::Context>>,

--- a/core/src/js_loading.rs
+++ b/core/src/js_loading.rs
@@ -1,4 +1,4 @@
-use rusty_v8 as v8;
+use v8;
 
 // Common code used by both `module.rs` and `script.rs`
 

--- a/core/src/js_loading.rs
+++ b/core/src/js_loading.rs
@@ -1,5 +1,3 @@
-use v8;
-
 // Common code used by both `module.rs` and `script.rs`
 
 pub(crate) fn create_script_origin<'s>(

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -8,7 +8,6 @@ mod module;
 mod script;
 
 pub(crate) use isolate_state::IsolateState;
-use v8;
 
 pub fn init(v8_flags: Option<Vec<String>>) {
     if let Some(mut v8_flags) = v8_flags {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -8,7 +8,7 @@ mod module;
 mod script;
 
 pub(crate) use isolate_state::IsolateState;
-use rusty_v8 as v8;
+use v8;
 
 pub fn init(v8_flags: Option<Vec<String>>) {
     if let Some(mut v8_flags) = v8_flags {

--- a/core/src/module.rs
+++ b/core/src/module.rs
@@ -1,7 +1,6 @@
 use crate::IsolateState;
 use std::collections::HashMap;
 use std::path::Path;
-use v8;
 
 pub(crate) struct ModuleMap {
     hash_to_absolute_path: HashMap<i32, String>,

--- a/core/src/module.rs
+++ b/core/src/module.rs
@@ -1,7 +1,7 @@
 use crate::IsolateState;
-use rusty_v8 as v8;
 use std::collections::HashMap;
 use std::path::Path;
+use v8;
 
 pub(crate) struct ModuleMap {
     hash_to_absolute_path: HashMap<i32, String>,

--- a/core/src/script.rs
+++ b/core/src/script.rs
@@ -1,4 +1,4 @@
-use rusty_v8 as v8;
+use v8;
 
 use crate::js_loading;
 

--- a/core/src/script.rs
+++ b/core/src/script.rs
@@ -1,5 +1,3 @@
-use v8;
-
 use crate::js_loading;
 
 pub(crate) fn run<'s>(

--- a/core/tests/test_api.rs
+++ b/core/tests/test_api.rs
@@ -28,15 +28,12 @@ mod api {
             Ok(_result) => panic!(),
             Err(e) => e,
         };
-        assert_eq!(
-            err.to_string(),
-            "ReferenceError: a is not defined\n    at jstime:1:1"
-        );
+        assert_eq!(err, "ReferenceError: a is not defined\n    at jstime:1:1");
         let err = match jstime.run_script("}", "jstime") {
             Ok(_result) => panic!(),
             Err(e) => e,
         };
-        assert_eq!(err.to_string(), "SyntaxError: Unexpected token \'}\'");
+        assert_eq!(err, "SyntaxError: Unexpected token \'}\'");
     }
     #[test]
     fn import() {
@@ -44,7 +41,7 @@ mod api {
         let options = jstime::Options::default();
         let mut jstime = jstime::JSTime::new(options);
         let hello_path = "./tests/fixtures/hello-world.js";
-        let _result = jstime.import(&hello_path);
+        let _result = jstime.import(hello_path);
         let result = jstime.run_script("globalThis.hello", "jstime");
         assert_eq!(result.unwrap(), "hello world");
     }


### PR DESCRIPTION
The `rusty_v8` project has been renamed to `v8`.

<!--
Thank you for your pull request. Please provide a description of your change.

Contributors guide: https://github.com/jstime/jstime/blob/HEAD/CONTRIBUTING.md
-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
