### PR TITLE
Add rust-url as WHATWG URL implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,6 +214,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "form_urlencoded"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
 name = "fslock"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -264,6 +274,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -289,6 +310,7 @@ name = "jstime_core"
 version = "0.39.1-alpha.0"
 dependencies = [
  "lazy_static",
+ "url",
  "v8",
 ]
 
@@ -312,6 +334,12 @@ checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
  "cfg-if 0.1.10",
 ]
+
+[[package]]
+name = "matches"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "memchr"
@@ -370,6 +398,12 @@ name = "once_cell"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
+
+[[package]]
+name = "percent-encoding"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "predicates"
@@ -623,10 +657,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c1c1d5a42b6245520c249549ec267180beaffcc0615401ac8e31853d4b6d8d2"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
 name = "treeline"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7f741b240f1a48843f9b8e0444fb55fb2a4ff67293b50a9179dfd5ea67f8d41"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-segmentation"
@@ -645,6 +709,18 @@ name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+
+[[package]]
+name = "url"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "matches",
+ "percent-encoding",
+]
 
 [[package]]
 name = "utf8parse"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/jstime/jstime"
 [dependencies]
 v8 = "0.39.0"
 lazy_static = "1.4.0"
+url = "2.2.2"
 
 [package.metadata.release]
 disable-tag = true

--- a/core/src/builtins/mod.rs
+++ b/core/src/builtins/mod.rs
@@ -1,4 +1,5 @@
 use std::convert::TryFrom;
+use url::Url;
 
 lazy_static! {
     pub(crate) static ref EXTERNAL_REFERENCES: v8::ExternalReferences =
@@ -8,6 +9,9 @@ lazy_static! {
             },
             v8::ExternalReference {
                 function: v8::MapFnTo::map_fn_to(queue_microtask),
+            },
+            v8::ExternalReference {
+                function: v8::MapFnTo::map_fn_to(url),
             },
         ]);
 }
@@ -28,6 +32,7 @@ impl Builtins {
 
         binding!("printer", printer);
         binding!("queueMicrotask", queue_microtask);
+        binding!("url", url);
 
         macro_rules! builtin {
             ($name:expr) => {
@@ -82,4 +87,8 @@ fn queue_microtask(
     let obj = args.get(0);
     let func = v8::Local::<v8::Function>::try_from(obj).unwrap();
     scope.enqueue_microtask(func);
+}
+
+fn url(scope: &mut v8::HandleScope, args: v8::FunctionCallbackArguments, _rv: v8::ReturnValue) {
+    
 }

--- a/core/tests/test_builtins.rs
+++ b/core/tests/test_builtins.rs
@@ -21,4 +21,14 @@ mod tests {
         let result = jstime.run_script("Object.keys(console);", "jstime");
         assert_eq!(result.unwrap(), "debug,error,info,log,warn,dir,dirxml,table,trace,group,groupCollapsed,groupEnd,clear,count,countReset,assert,profile,profileEnd,time,timeLog,timeEnd,timeStamp,context");
     }
+    #[test]
+    fn url() {
+        let _setup_guard = common::setup();
+        let options = jstime::Options::default();
+        let mut jstime = jstime::JSTime::new(options);
+        let result = jstime.run_script("typeof URL;", "jstime");
+        assert_eq!(result.unwrap(), "function");
+        let result = jstime.run_script("typeof URLSearchParams;", "jstime");
+        assert_eq!(result.unwrap(), "function");
+    }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description of your change.

Contributors guide: https://github.com/jstime/jstime/blob/HEAD/CONTRIBUTING.md
-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Rather than rolling yet another URL implementation, I'm going to take a stab at integrating the very popular rust-url dependency into this runtime. Ideally, if we do want our own implementation in the future we can continue to use this integration and just swap out the dependency.
