### PR TITLE
chore: fix test

### DIFF
--- a/core/tests/test_conformance_base64.rs
+++ b/core/tests/test_conformance_base64.rs
@@ -270,7 +270,7 @@ mod conformance_base64 {
         let _setup_guard = common::setup();
         let options = jstime::Options::default();
         let mut jstime = jstime::JSTime::new(options);
-        let result = jstime.run_script("atob(123);", "test");
+        let _result = jstime.run_script("atob(123);", "test");
         // This should throw due to invalid base64 length
         let result = jstime.run_script(
             "try { atob(123); 'no error'; } catch(e) { 'error'; }",


### PR DESCRIPTION
This pull request makes a minor change to the `mod conformance_base64` test in `core/tests/test_conformance_base64.rs` by renaming the unused variable `result` to `_result` to indicate that its value is intentionally ignored.